### PR TITLE
MiniMessage-like Sound Tags

### DIFF
--- a/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
@@ -350,6 +350,7 @@ public class ChatColorHandler {
             parsers.register(MiniMessageInteractionParser.INSTANCE, 72);
             parsers.register(MiniMessagePlaceholderParser.INSTANCE, 71);
             parsers.register(MiniMessageTextFormattingParser.INSTANCE, 70);
+            parsers().register(SoundParser.INSTANCE, 69);
             ChatColorHandler.debugLog("Found MiniMessage in Server. MiniMessage support enabled.");
         } else {
             ChatColorHandler.messenger(new LegacyMessenger());

--- a/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
@@ -339,6 +339,7 @@ public class ChatColorHandler {
 
         parsers.register(HexParser.INSTANCE, 83);
         parsers.register(SpigotParser.INSTANCE, 65);
+        parsers.register(SoundParser.INSTANCE, 60);
 
         if (isPaper()) {
             ChatColorHandler.messenger(new MiniMessageMessenger());
@@ -350,7 +351,6 @@ public class ChatColorHandler {
             parsers.register(MiniMessageInteractionParser.INSTANCE, 72);
             parsers.register(MiniMessagePlaceholderParser.INSTANCE, 71);
             parsers.register(MiniMessageTextFormattingParser.INSTANCE, 70);
-            parsers().register(SoundParser.INSTANCE, 69);
             ChatColorHandler.debugLog("Found MiniMessage in Server. MiniMessage support enabled.");
         } else {
             ChatColorHandler.messenger(new LegacyMessenger());

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/ParserTypes.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/ParserTypes.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public class ParserTypes {
     public static final String COLOR = "color";
+    public static final String SOUND = "sound";
     public static final String INTERACTION = "interaction";
     public static final String PLACEHOLDER = "placeholder";
     public static final String TEXT_FORMATTING = "text-formatting";
@@ -15,6 +16,13 @@ public class ParserTypes {
      */
     public static List<Parser> color() {
         return ChatColorHandler.parsers().ofType(COLOR);
+    }
+
+    /**
+     * @return A list of sound based parsers
+     */
+    public static List<Parser> sound() {
+        return ChatColorHandler.parsers().ofType(SOUND);
     }
 
     /**

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
@@ -20,6 +20,8 @@ public class SoundParser implements Parser {
 
     public static final SoundParser INSTANCE = new SoundParser();
 
+    private SoundParser() {}
+
     @Override
     public String getType() {
         return ParserTypes.SOUND;

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
@@ -1,7 +1,6 @@
 package org.lushplugins.chatcolorhandler.parsers.custom;
 
 import org.bukkit.Location;
-import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.lushplugins.chatcolorhandler.parsers.Parser;
@@ -48,9 +47,7 @@ public class SoundParser implements Parser {
 
         while (soundMatcher.find()) {
             try {
-                String soundName = soundMatcher.group(1);
-                Sound sound = Sound.valueOf(soundName);
-
+                String sound = soundMatcher.group(1).toLowerCase();
                 float volume = soundMatcher.group(2) != null ?
                         Float.parseFloat(soundMatcher.group(2)) : DEFAULT_VOLUME;
                 float pitch = soundMatcher.group(3) != null ?

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
@@ -1,0 +1,63 @@
+package org.lushplugins.chatcolorhandler.parsers.custom;
+
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.lushplugins.chatcolorhandler.parsers.Parser;
+import org.lushplugins.chatcolorhandler.parsers.ParserTypes;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SoundParser implements Parser {
+
+    private static final Pattern SOUND_PATTERN =
+            Pattern.compile("<sound:([A-Z_]+):([0-9.]+):([0-9.]+)>");
+
+    public static final SoundParser INSTANCE = new SoundParser();
+
+    private SoundParser() {}
+
+    @Override
+    public String getType() {
+        return ParserTypes.SOUND;
+    }
+
+    @Override
+    public String parseString(@NotNull String string, @NotNull OutputType outputType) {
+        return string;
+    }
+
+    @Override
+    public String parseString(@NotNull String string, @NotNull OutputType outputType, Player player) {
+        if (!string.contains("<sound:")) {
+            return string;
+        }
+
+        Matcher soundMatcher = SOUND_PATTERN.matcher(string);
+
+        if (!soundMatcher.find()) {
+            return string;
+        }
+
+        soundMatcher.reset();
+
+        while (soundMatcher.find()) {
+            try {
+                String soundName = soundMatcher.group(1);
+                Sound sound = Sound.valueOf(soundName);
+
+                float volume = Float.parseFloat(soundMatcher.group(2));
+                float pitch = Float.parseFloat(soundMatcher.group(3));
+
+                Location playerLoc = player.getLocation();
+                player.playSound(playerLoc, sound, volume, pitch);
+            } catch (IllegalArgumentException ignored) {
+                // ignore IllegalArgumentException
+            }
+        }
+
+        return soundMatcher.reset().replaceAll("");
+    }
+}

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/SoundParser.java
@@ -13,11 +13,12 @@ import java.util.regex.Pattern;
 public class SoundParser implements Parser {
 
     private static final Pattern SOUND_PATTERN =
-            Pattern.compile("<sound:([A-Z_]+):([0-9.]+):([0-9.]+)>");
+            Pattern.compile("<sound:([A-Za-z0-9._-]+)(?::([0-9.]+))?(?::([0-9.]+))?>");
+
+    private static final float DEFAULT_VOLUME = 1.0f;
+    private static final float DEFAULT_PITCH = 1.0f;
 
     public static final SoundParser INSTANCE = new SoundParser();
-
-    private SoundParser() {}
 
     @Override
     public String getType() {
@@ -48,8 +49,10 @@ public class SoundParser implements Parser {
                 String soundName = soundMatcher.group(1);
                 Sound sound = Sound.valueOf(soundName);
 
-                float volume = Float.parseFloat(soundMatcher.group(2));
-                float pitch = Float.parseFloat(soundMatcher.group(3));
+                float volume = soundMatcher.group(2) != null ?
+                        Float.parseFloat(soundMatcher.group(2)) : DEFAULT_VOLUME;
+                float pitch = soundMatcher.group(3) != null ?
+                        Float.parseFloat(soundMatcher.group(3)) : DEFAULT_PITCH;
 
                 Location playerLoc = player.getLocation();
                 player.playSound(playerLoc, sound, volume, pitch);


### PR DESCRIPTION
MiniMessage-like sound tags that allow for the usage of sounds within messages, titles, & actionbars.

**SoundParser**
- Returns unmodified message when there is no player context.
- Plays sound and removes tags when player context is provided.

**Example Usage**

````Java
@EventHandler
public void onJump(PlayerPickupExperienceEvent event) {
    ChatColorHandler.sendMessage(event.getPlayer(), 
            "<sound:ENTITY_EXPERIENCE_ORB_PICKUP:1.0:1.0>You gained experience!");
}
````

*Originally made for personal use but thought why not open a PR in case you're interested :)*