### PR TITLE
Particle tags in messages

### DIFF
--- a/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/ChatColorHandler.java
@@ -340,6 +340,7 @@ public class ChatColorHandler {
         parsers.register(HexParser.INSTANCE, 83);
         parsers.register(SpigotParser.INSTANCE, 65);
         parsers.register(SoundParser.INSTANCE, 60);
+        parsers.register(ParticleParser.INSTANCE, 59);
 
         if (isPaper()) {
             ChatColorHandler.messenger(new MiniMessageMessenger());

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/ParserTypes.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/ParserTypes.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class ParserTypes {
     public static final String COLOR = "color";
     public static final String SOUND = "sound";
+    public static final String PARTICLE = "particle";
     public static final String INTERACTION = "interaction";
     public static final String PLACEHOLDER = "placeholder";
     public static final String TEXT_FORMATTING = "text-formatting";
@@ -23,6 +24,13 @@ public class ParserTypes {
      */
     public static List<Parser> sound() {
         return ChatColorHandler.parsers().ofType(SOUND);
+    }
+
+    /**
+     * @return A list of particle based parsers
+     */
+    public static List<Parser> particle() {
+        return ChatColorHandler.parsers().ofType(PARTICLE);
     }
 
     /**

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
@@ -66,7 +66,7 @@ public class ParticleParser implements Parser {
 
     private Location parseLocation(String locationStr, Player player) {
         Location playerLoc = player.getLocation();
-        String[] parts = locationStr.split(",\\s*", 3);
+        String[] parts = locationStr.split(",\\s", 3);
 
         if (parts.length != 3) {
             return playerLoc;

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
@@ -66,7 +66,7 @@ public class ParticleParser implements Parser {
 
     private Location parseLocation(String locationStr, Player player) {
         Location playerLoc = player.getLocation();
-        String[] parts = locationStr.split(",\\s", 3);
+        String[] parts = locationStr.split(",\\s?", 3);
 
         if (parts.length != 3) {
             return playerLoc;

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
@@ -66,7 +66,7 @@ public class ParticleParser implements Parser {
 
     private Location parseLocation(String locationStr, Player player) {
         Location playerLoc = player.getLocation();
-        String[] parts = locationStr.split(", ", 3);
+        String[] parts = locationStr.split(",\\s*", 3);
 
         if (parts.length != 3) {
             return playerLoc;

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/ParticleParser.java
@@ -1,0 +1,94 @@
+package org.lushplugins.chatcolorhandler.parsers.custom;
+
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.lushplugins.chatcolorhandler.parsers.Parser;
+import org.lushplugins.chatcolorhandler.parsers.ParserTypes;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ParticleParser implements Parser {
+
+    private static final Pattern PARTICLE_PATTERN = Pattern.compile("<particle:([a-zA-Z_]+)(?::([~\\d.-]+, [~\\d.-]+, [~\\d.-]+))?(?::(\\d+))?>");
+
+    public  static final ParticleParser INSTANCE = new ParticleParser();
+
+    private ParticleParser() {}
+
+    @Override
+    public String getType() {
+        return ParserTypes.PARTICLE;
+    }
+
+    @Override
+    public String parseString(@NotNull String string, @NotNull OutputType outputType) {
+        return string;
+    }
+
+    @Override
+    public String parseString(@NotNull String string, @NotNull Parser.OutputType outputType, Player player) {
+        if (!string.contains("<particle:")) {
+            return string;
+        }
+
+        Matcher particleMatcher = PARTICLE_PATTERN.matcher(string);
+
+        if (!particleMatcher.find()) {
+            return string;
+        }
+
+        particleMatcher.reset();
+
+        while (particleMatcher.find()) {
+            try {
+                String particleName = particleMatcher.group(1).toUpperCase();
+                Particle particle = Particle.valueOf(particleName);
+
+                String locationStr = particleMatcher.group(2);
+                Location location = locationStr != null ?
+                        parseLocation(locationStr, player) :
+                        player.getLocation();
+
+                int count = particleMatcher.group(3) != null ?
+                        Integer.parseInt(particleMatcher.group(3)) : 1;
+
+                player.spawnParticle(particle, location, count);
+            } catch (IllegalArgumentException ignored) {
+                // ignore IllegalArgumentException
+            }
+        }
+
+        return particleMatcher.reset().replaceAll("");
+    }
+
+    private Location parseLocation(String locationStr, Player player) {
+        Location playerLoc = player.getLocation();
+        String[] parts = locationStr.split(", ", 3);
+
+        if (parts.length != 3) {
+            return playerLoc;
+        }
+
+        double x = parseCoordinate(parts[0], playerLoc.getX());
+        double y = parseCoordinate(parts[1], playerLoc.getY());
+        double z = parseCoordinate(parts[2], playerLoc.getZ());
+        return new Location(player.getWorld(), x, y, z);
+    }
+
+    private double parseCoordinate(String coordinate, double playerCoord) {
+        if (coordinate.isEmpty()) {
+            return playerCoord;
+        }
+
+        if (coordinate.charAt(0) == '~') {
+            return coordinate.length() == 1 ?
+                    playerCoord :
+                    playerCoord + Double.parseDouble(coordinate.substring(1));
+        }
+
+        return Double.parseDouble(coordinate);
+    }
+}


### PR DESCRIPTION
### Description

This pull request adds support for particle tags, similar to sound tags, this allows you to use particles in messages, titles, and action bars.


### ParticleParser

- `getType()`: Returns the parser type as `ParserTypes.PARTICLE`.

-  `parseString(String string, OutputType outputType)`: Returns the input string without modification.

- `parseString(String string, OutputType outputType, Player player)`: Parses the input string to identify particle tags and spawns the specified particles at the given locations or the player's location, with the specified amount.

- `parseLocation(String locationStr, Player player)`: Parses location strings to determine coordinates based on the player's current location.
- `parseCoordinate(String coordinate, double playerCoord)`: Parses individual coordinate values, supporting relative coordinates with the `~` symbol.

### Usage

You can specify particle effects in messages using the format: `<particle:PARTICLE_NAME:LOCATION?:COUNT?>`.

### Example

````Java
@EventHandler
public void onToggleSneak(PlayerToggleSneakEvent event) {
    ChatColorHandler.sendActionBarMessage(event.getPlayer(), "<particle:FLAME:~, ~2, ~:1000><gold><bold>FLAME!");
}
````

![grafik](https://github.com/user-attachments/assets/e8be9f65-5962-428b-bbd2-7bf3fe65204c)