### PR TITLE
Fixed MiniPlaceholders v3 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ allprojects {
 }
 
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
     compileOnly("net.kyori:adventure-text-serializer-legacy:4.24.0")
     compileOnly("net.kyori:adventure-text-minimessage:4.24.0")
     compileOnly("io.github.miniplaceholders:miniplaceholders-api:3.0.1")

--- a/src/main/java/org/lushplugins/chatcolorhandler/ModernChatColorHandler.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/ModernChatColorHandler.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.NotNull;
 import org.lushplugins.chatcolorhandler.messengers.MiniMessageMessenger;
 import org.lushplugins.chatcolorhandler.parsers.Parser;
 import org.lushplugins.chatcolorhandler.parsers.Resolver;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
@@ -62,12 +61,12 @@ public class ModernChatColorHandler {
 
         String legacyParsed = ChatColorHandler.parsers().parseString(string, Parser.OutputType.MINI_MESSAGE, player, parsers);
 
-        TagResolver tagResolver = Resolver.combineResolvers((Audience) player, parsers.stream()
+        TagResolver tagResolver = Resolver.combineResolvers(player, parsers.stream()
             .map(parser -> parser instanceof Resolver resolver ? resolver : null)
             .filter(Objects::nonNull)
             .toList());
 
-        return MiniMessageMessenger.MINI_MESSAGE.deserialize(legacyParsed, tagResolver);
+        return MiniMessageMessenger.MINI_MESSAGE.deserialize(legacyParsed, player, tagResolver);
     }
 
     /**

--- a/src/main/java/org/lushplugins/chatcolorhandler/messengers/MiniMessageMessenger.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/messengers/MiniMessageMessenger.java
@@ -2,7 +2,6 @@ package org.lushplugins.chatcolorhandler.messengers;
 
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.lushplugins.chatcolorhandler.ModernChatColorHandler;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -33,9 +32,8 @@ public class MiniMessageMessenger extends AbstractMessenger {
             return;
         }
 
-        Audience audience = Audience.audience((Audience) recipient);
         Component parsed = ModernChatColorHandler.translate(message, (recipient instanceof Player player ? player : null));
-        audience.sendMessage(parsed);
+        recipient.sendMessage(parsed);
     }
 
     @Override
@@ -44,8 +42,7 @@ public class MiniMessageMessenger extends AbstractMessenger {
             return;
         }
 
-        Audience audience = Audience.audience((Audience) Bukkit.getServer());
-        audience.sendMessage(ModernChatColorHandler.translate(message));
+        Bukkit.getServer().sendMessage(ModernChatColorHandler.translate(message));
     }
 
     @Override
@@ -54,8 +51,7 @@ public class MiniMessageMessenger extends AbstractMessenger {
             return;
         }
 
-        Audience audience = Audience.audience((Audience) player);
-        audience.sendActionBar(ModernChatColorHandler.translate(message, player));
+        player.sendActionBar(ModernChatColorHandler.translate(message, player));
     }
 
     @Override
@@ -64,10 +60,9 @@ public class MiniMessageMessenger extends AbstractMessenger {
             return;
         }
 
-        Audience audience = Audience.audience((Audience) player);
         Title.Times times = Title.Times.times(Duration.ofMillis(fadeIn * 50L), Duration.ofMillis(stay * 50L), Duration.ofMillis(fadeOut * 50L));
-        audience.sendTitlePart(TitlePart.TIMES, times);
-        audience.sendTitlePart(TitlePart.SUBTITLE, ModernChatColorHandler.translate(subtitle, player));
-        audience.sendTitlePart(TitlePart.TITLE, ModernChatColorHandler.translate(title, player));
+        player.sendTitlePart(TitlePart.TIMES, times);
+        player.sendTitlePart(TitlePart.SUBTITLE, ModernChatColorHandler.translate(subtitle, player));
+        player.sendTitlePart(TitlePart.TITLE, ModernChatColorHandler.translate(title, player));
     }
 }

--- a/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/MiniMessageResolverParser.java
+++ b/src/main/java/org/lushplugins/chatcolorhandler/parsers/custom/MiniMessageResolverParser.java
@@ -1,6 +1,5 @@
 package org.lushplugins.chatcolorhandler.parsers.custom;
 
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -33,8 +32,8 @@ public class MiniMessageResolverParser implements Parser {
             case SPIGOT -> {
                 string = string.replace('§', '&');
 
-                TagResolver resolver = Resolver.combineResolvers(player instanceof Audience audience ? audience : null, getPlaceholderResolvers());
-                yield MiniMessageMessenger.LEGACY_COMPONENT_SERIALIZER.serialize(MiniMessageMessenger.MINI_MESSAGE.deserialize(string, resolver));
+                TagResolver resolver = Resolver.combineResolvers(player, getPlaceholderResolvers());
+                yield MiniMessageMessenger.LEGACY_COMPONENT_SERIALIZER.serialize(MiniMessageMessenger.MINI_MESSAGE.deserialize(string, player, resolver));
             }
             case MINI_MESSAGE -> string;
         };


### PR DESCRIPTION
https://miniplaceholders.github.io/docs/developer-guide/Integration#obtaining-placeholders

> The classes related to MiniMessage were also updated to a more native use of Adventure. This is because they will run exclusively in Paper environments, so there will be no problems on servers 1.21 or higher.